### PR TITLE
Fix uint8array infinite loop

### DIFF
--- a/src/helpers/u8array/uint8array.ts
+++ b/src/helpers/u8array/uint8array.ts
@@ -39,6 +39,9 @@ export class U8Array extends Uint8Array {
       } else {
         needleIndex = 1;
         i = this.indexOf(needle[0], i);
+        if (i == -1) {
+          return -1;
+        }
       }
     }
 


### PR DESCRIPTION
I found that whenever I would load a save file the page would freeze. 

No idea if my save files are different (I tried multiple), but once it got to the end of the file `indexOf()` would not find the needle and return -1, which restarts the for loop.

I only looked at the code I needed for the fix so no idea if this breaks some edge cases, but it seems to work for me. 