### PR TITLE
fix(resources): use section offset instead of header offset

### DIFF
--- a/src/helpers/u8array/__tests__/uin8array.spec.ts
+++ b/src/helpers/u8array/__tests__/uin8array.spec.ts
@@ -26,7 +26,7 @@ describe('U8Array', () => {
   ];
 
   describe.each(cases)('UUID as $type', ({ uuid }) => {
-    test.skip(`Should find the UUID ${uuid.toString()}`, () => {
+    test(`Should find the UUID ${uuid.toString()}`, () => {
       expect(haystack.indexOfMulti(uuid)).toBe(44_531);
     });
 

--- a/src/helpers/u8array/uint8array.ts
+++ b/src/helpers/u8array/uint8array.ts
@@ -22,7 +22,7 @@ export class U8Array extends Uint8Array {
     const hexNeedle =
       typeof needle === 'string' ? hexStringToByteArray(needle) : needle;
 
-    let index = Array.prototype.indexOf.call(this, needle[0], offset);
+    let index = Array.prototype.indexOf.call(this, hexNeedle[0], offset);
 
     if (hexNeedle.length === 1 || index === -1) {
       // Not found or no other elements to check
@@ -86,11 +86,11 @@ export class U8Array extends Uint8Array {
     this.set(u8, index + hexNeedle.length + offset);
   }
 
-  public getFloat32(needle: UUID, offset = 0): number {
+  public getFloat32(needle: UUID, offset = 0, from = HEADER_OFFSET): number {
     const hexNeedle =
       typeof needle === 'string' ? hexStringToByteArray(needle) : needle;
 
-    const index = this.indexOfMulti(hexNeedle, HEADER_OFFSET);
+    const index = this.indexOfMulti(hexNeedle, from);
     if (index === -1) {
       return -1;
     }
@@ -102,10 +102,15 @@ export class U8Array extends Uint8Array {
     return view.getFloat32(0, true);
   }
 
-  public setFloat32(needle: UUID, offset: number, value: number): void {
+  public setFloat32(
+    needle: UUID,
+    offset: number,
+    value: number,
+    from = HEADER_OFFSET
+  ): void {
     const hexNeedle =
       typeof needle === 'string' ? hexStringToByteArray(needle) : needle;
-    const index = this.indexOfMulti(hexNeedle, HEADER_OFFSET);
+    const index = this.indexOfMulti(hexNeedle, from);
     const view = new DataView(new ArrayBuffer(FLOAT32_NUM_BYTES));
     view.setFloat32(0, value, true);
 

--- a/src/views/editor/resources/resourceInput/resourceInput.tsx
+++ b/src/views/editor/resources/resourceInput/resourceInput.tsx
@@ -6,13 +6,14 @@ interface Properties {
   name: string;
   item: string;
   uuid: number[];
+  from: number;
 }
 
-function ResourceInput({ name, item, uuid }: Properties): ReactElement {
+function ResourceInput({ name, item, uuid, from }: Properties): ReactElement {
   const {
     state: { amount },
     actions: { onInputChange }
-  } = useResourceInput({ item, uuid });
+  } = useResourceInput({ item, uuid, from });
 
   return (
     <Input

--- a/src/views/editor/resources/resourceInput/useResourceInput.ts
+++ b/src/views/editor/resources/resourceInput/useResourceInput.ts
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 interface Properties {
   item: string;
   uuid: number[];
+  from: number;
 }
 
 interface ReturnType {
@@ -17,7 +18,7 @@ interface ReturnType {
   };
 }
 
-function useResourceInput({ item, uuid }: Properties): ReturnType {
+function useResourceInput({ item, uuid, from }: Properties): ReturnType {
   const saveReference = useRef(useSaveStore.getState());
   const { save, setSave } = saveReference.current;
 
@@ -28,7 +29,7 @@ function useResourceInput({ item, uuid }: Properties): ReturnType {
     let resources = 0;
     resources = [ITEMS.CREDITS as string].includes(item)
       ? save.getInt32(uuid, 0)
-      : save.getFloat32(uuid, 0);
+      : save.getFloat32(uuid, 0, from);
 
     return resources < 0 ? 0 : resources;
   });
@@ -53,7 +54,7 @@ function useResourceInput({ item, uuid }: Properties): ReturnType {
     if ([ITEMS.CREDITS as string].includes(item)) {
       save.setInt32(uuid, 0, value);
     } else {
-      save.setFloat32(uuid, 0, value);
+      save.setFloat32(uuid, 0, value, from);
     }
 
     setSave(save);

--- a/src/views/editor/resources/resources.tsx
+++ b/src/views/editor/resources/resources.tsx
@@ -4,10 +4,16 @@ import {
   EXPANDED_RESOURCE_NAMES,
   RESOURCES
 } from '@/constant/resources';
+import { b } from '@/helpers';
+import useSaveStore from '@/stores/saveStore';
 import type { ReactElement } from 'react';
+import { useRef } from 'react';
 import ResourceInput from './resourceInput/resourceInput';
 
 function Resources(): ReactElement {
+  const saveReference = useRef(useSaveStore.getState());
+  const offset = saveReference.current.save.indexOfMulti(b`Resources`);
+
   return (
     <div className='w-full' id='resources'>
       {Object.entries(CATEGORIES).map(([category, items]) => (
@@ -22,6 +28,7 @@ function Resources(): ReactElement {
                 item={item}
                 name={EXPANDED_RESOURCE_NAMES[item] || item}
                 uuid={RESOURCES[item]}
+                from={offset}
               />
             ))}
           </div>


### PR DESCRIPTION
The latest update changed the save structure and now the section `Known minerals` comes before `Resources`, breaking the logic. This change finds the offset of `Resouces` section to use as a starting point

fix #40